### PR TITLE
Fix division operation

### DIFF
--- a/consistent.go
+++ b/consistent.go
@@ -176,8 +176,9 @@ func (c *Consistent) averageLoad() float64 {
 	if len(c.members) == 0 {
 		return 0
 	}
-
-	avgLoad := float64(c.partitionCount/uint64(len(c.members))) * c.config.Load
+	partitionCountFloat := float64(c.partitionCount)
+	memberCountFloat := float64(len(c.members))
+	avgLoad := (partitionCountFloat / memberCountFloat) * c.config.Load
 	return math.Ceil(avgLoad)
 }
 


### PR DESCRIPTION
We need this change for better partition distribution and eventually resulting better key distribution. This is required for smaller number of machines, in our case which is shards.